### PR TITLE
Add pytest tests for scenario loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ pip install -r requirements.txt
 PERPLEXITY_API_KEY=dein_api_key
 ```
 
+### Tests ausführen
+
+Nach dem Einrichten der Umgebung kannst du die automatischen Tests mit
+
+```bash
+pytest
+```
+
 ---
 
 ## ▶️ Spiel starten

--- a/tests/test_scenario_data.py
+++ b/tests/test_scenario_data.py
@@ -1,0 +1,27 @@
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from scenario_data import load_scenario, Scenario
+
+
+def test_load_scenario_spionage01():
+    scenario = load_scenario("SPIONAGE01")
+    assert isinstance(scenario, Scenario)
+    assert scenario.title
+    assert len(scenario.suspects) == 3
+    assert scenario.culprit_id == "B"
+
+
+def test_get_suspect_case_insensitive():
+    scenario = load_scenario("SPIONAGE01")
+    suspect = scenario.get_suspect("a")
+    assert suspect is not None
+    assert suspect.name == "Peter Schmidt"
+    assert scenario.get_suspect("B").is_culprit
+
+
+def test_get_suspect_invalid():
+    scenario = load_scenario("SPIONAGE01")
+    assert scenario.get_suspect("Z") is None


### PR DESCRIPTION
## Summary
- add pytest unit tests for scenario loading and suspect lookup
- document how to run tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6ac489dc832196900995dea2b58a