### PR TITLE
Add minigame integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@
 - 🔊 TTS-Ausgabe mit Stimme (wenn verfügbar)
 - 🧠 Zufällige Geheimnisse & Reaktionsmuster
 - 📈 Steigende Spannung durch **Verdachts-Indikator**
+- 🔐 Kleines Minispiel "Codebreaker" zum Freischalten zusätzlicher Hinweise
+- 🕵️‍♀️ Minispiel "Spurenanalyse" zum Zuordnen von Hinweisen
+- 🎴 Gedächtnisspiel "Aussagen merken" für bessere Beobachtung
+- 💬 Minispiel "Lügendetektor" zum Aufdecken von Stressmustern
+- 🧩 Minispiel "Indizien-Puzzle" zum Zusammensetzen von Fotos
+- 📂 Minispiel "Beweismittelkette" zum zeitlichen Zuordnen von Beweisen
+- Neu: Während der Befragung kannst du mit dem Befehl `minigame` ein zufälliges
+  Minispiel starten, um einen zusätzlichen Hinweis zu erhalten.
 
 ---
 

--- a/main.py
+++ b/main.py
@@ -12,7 +12,8 @@ from voice_interface import speak, get_user_input, get_user_accusation_input
 # Importiere die initialisierten Objekte direkt, wenn sie global in voice_interface sind
 # oder initialisiere sie hier, falls sie nicht global sind.
 # Annahme: stt_model und tts_engine sind in voice_interface initialisiert und importierbar
-from voice_interface import stt_model, tts_engine 
+from voice_interface import stt_model, tts_engine
+from minigames import play_random_minigame
 
 # --- Angepasste Hybrid-Antwort Funktion ---
 def get_answer(suspect, question, conversation_history):
@@ -109,15 +110,24 @@ if __name__ == "__main__":
             speak(f"Noch {remaining_q_suspect} Fragen für {current_suspect.name}.")
 
             # *** NEU: get_user_input nutzen, das 'wechseln'/'raten' erkennt ***
-            user_input_raw = get_user_input("Deine Frage (oder 'wechseln'/'raten')")
+            user_input_raw = get_user_input("Deine Frage (oder 'wechseln'/'raten'/'minigame')")
             
             # Befehle zuerst prüfen
-            if user_input_raw.lower() == 'wechseln':
+            cmd = user_input_raw.lower()
+            if cmd == 'wechseln':
                  print("Wechsle Verdächtigen..."); speak("Wechsle Verdächtigen.")
-                 break # Beende innere Schleife, gehe zur äußeren
-            if user_input_raw.lower() == 'raten':
-                 suspect_choice_id = 'ENDE' # Signal zum Beenden der äußeren Schleife
-                 break # Beende innere Schleife
+                 break
+            if cmd == 'raten':
+                 suspect_choice_id = 'ENDE'
+                 break
+            if cmd == 'minigame' or cmd == 'spiel':
+                 won = play_random_minigame()
+                 if won:
+                     hint = current_scenario.get_bonus_hint()
+                     if hint:
+                         print(f"[Hinweis] {hint}")
+                         speak(hint)
+                 continue
 
             question = user_input_raw # Es ist eine Frage
             if not question: continue

--- a/minigames/__init__.py
+++ b/minigames/__init__.py
@@ -1,0 +1,41 @@
+"""Minigame helper functions."""
+
+import random
+from typing import Callable
+
+from .codebreaker import play_codebreaker
+from .trace_analysis import play_trace_analysis
+from .memory_game import play_memory_game
+from .lie_detector import play_lie_detector
+from .clue_puzzle import play_clue_puzzle
+from .evidence_chain import play_evidence_chain
+
+
+def play_random_minigame() -> bool:
+    """Play a randomly chosen minigame and return True if solved."""
+    games: list[Callable[[], bool]] = [
+        play_codebreaker,
+        lambda: play_trace_analysis([
+            {"clue": "SUV-Spuren vor dem Gebäude", "suspect": "Sandra"},
+            {"clue": "Blondes Haar im Büro", "suspect": "Peter"},
+        ]),
+        lambda: play_memory_game([
+            {"suspect": "Peter", "statement": "Ich war im Büro."},
+            {"suspect": "Sandra", "statement": "Ich war im Restaurant."},
+            {"suspect": "Klaus", "statement": "Ich habe meine Runde gemacht."},
+        ]),
+        lambda: play_lie_detector([
+            {"suspect": "Peter", "statement": "Ich habe keine Schulden.", "is_lie": True, "stress": 3},
+            {"suspect": "Sandra", "statement": "Ich war den ganzen Abend beim Essen.", "is_lie": True, "stress": 4},
+            {"suspect": "Klaus", "statement": "Ich habe gearbeitet.", "is_lie": False, "stress": 1},
+        ]),
+        lambda: play_clue_puzzle(["Teil A", "Teil B", "Teil C", "Teil D"]),
+        lambda: play_evidence_chain([
+            "Verdächtiger verlässt das Haus",
+            "Kamera zeichnet ihn auf",
+            "Einbruch passiert",
+            "Polizei trifft ein",
+        ]),
+    ]
+    game = random.choice(games)
+    return game()

--- a/minigames/clue_puzzle.py
+++ b/minigames/clue_puzzle.py
@@ -1,0 +1,41 @@
+import random
+from typing import List
+
+
+def evaluate_order(solution: List[str], proposed: List[str]) -> bool:
+    """Return True if proposed order matches the solution exactly."""
+    return solution == proposed
+
+
+def play_clue_puzzle(pieces: List[str]) -> bool:
+    """Terminal mini-game to order puzzle pieces correctly."""
+    if not pieces:
+        print("Keine Puzzleteile vorhanden.")
+        return False
+
+    solution = pieces[:]
+    shuffled = pieces[:]
+    random.shuffle(shuffled)
+    print("[Indizien-Puzzle] Bringe die Teile in die richtige Reihenfolge:")
+    for idx, piece in enumerate(shuffled, 1):
+        print(f" {idx}. {piece}")
+
+    ans = input("Reihenfolge der Nummern (z.B. '2 1 3 4'): ").strip().split()
+    try:
+        indices = [int(a) - 1 for a in ans]
+        proposed = [shuffled[i] for i in indices]
+    except (ValueError, IndexError):
+        print("Ung\xC3\xBCltige Eingabe.")
+        return False
+
+    if evaluate_order(solution, proposed):
+        print("Richtig! Hinweis entdeckt.")
+        return True
+    print("Leider falsch.")
+    print("Richtige Reihenfolge:", " ".join(solution))
+    return False
+
+
+if __name__ == "__main__":
+    demo_pieces = ["Teil A", "Teil B", "Teil C", "Teil D"]
+    play_clue_puzzle(demo_pieces)

--- a/minigames/codebreaker.py
+++ b/minigames/codebreaker.py
@@ -1,0 +1,50 @@
+import random
+
+CODE_LENGTH = 4
+MAX_ATTEMPTS = 10
+
+def generate_code(length=CODE_LENGTH):
+    """Generate a random numeric code as string."""
+    return ''.join(str(random.randint(0, 9)) for _ in range(length))
+
+
+def evaluate_guess(code: str, guess: str):
+    """Return count of correct digits in correct place and correct digits in wrong place."""
+    if len(code) != len(guess):
+        raise ValueError("guess must have same length as code")
+    # Count correct positions
+    correct_pos = sum(c == g for c, g in zip(code, guess))
+    # Count occurrences
+    code_counts = {}
+    guess_counts = {}
+    for c in code:
+        code_counts[c] = code_counts.get(c, 0) + 1
+    for g in guess:
+        guess_counts[g] = guess_counts.get(g, 0) + 1
+    total_matches = sum(min(code_counts.get(d, 0), guess_counts.get(d, 0)) for d in guess_counts)
+    wrong_pos = total_matches - correct_pos
+    return correct_pos, wrong_pos
+
+
+def play_codebreaker():
+    """Simple terminal Codebreaker game. Returns True if solved."""
+    code = generate_code()
+    attempts = 0
+    print(f"[Codebreaker] Es wurde ein {len(code)}-stelliger Code erzeugt. Versuche ihn zu knacken!")
+    while attempts < MAX_ATTEMPTS:
+        guess = input(f"Versuch {attempts+1}/{MAX_ATTEMPTS}: ").strip()
+        if len(guess) != len(code) or not guess.isdigit():
+            print(f"Bitte einen {len(code)}-stelligen Code eingeben.")
+            continue
+        attempts += 1
+        correct, wrong = evaluate_guess(code, guess)
+        if correct == len(code):
+            print("Richtig! Schloss geöffnet.")
+            return True
+        print(f"{correct} Stellen korrekt, {wrong} richtige Zahl an falscher Position.")
+    print(f"Leider verloren! Der Code war {code}.")
+    return False
+
+
+if __name__ == "__main__":
+    play_codebreaker()

--- a/minigames/evidence_chain.py
+++ b/minigames/evidence_chain.py
@@ -1,0 +1,46 @@
+import random
+from typing import List
+
+
+def evaluate_sequence(solution: List[str], proposed: List[str]) -> bool:
+    """Return True if proposed sequence matches the correct order exactly."""
+    return solution == proposed
+
+
+def play_evidence_chain(events: List[str]) -> bool:
+    """Terminal mini-game to arrange events in the correct order."""
+    if not events:
+        print("Keine Ereignisse vorhanden.")
+        return False
+
+    solution = events[:]
+    shuffled = events[:]
+    random.shuffle(shuffled)
+    print("[Beweismittelkette] Bringe die Ereignisse in die richtige Reihenfolge:")
+    for idx, ev in enumerate(shuffled, 1):
+        print(f" {idx}. {ev}")
+
+    ans = input("Reihenfolge der Nummern (z.B. '2 1 3 4'): ").strip().split()
+    try:
+        indices = [int(a) - 1 for a in ans]
+        proposed = [shuffled[i] for i in indices]
+    except (ValueError, IndexError):
+        print("Ung\xC3\xBCltige Eingabe.")
+        return False
+
+    if evaluate_sequence(solution, proposed):
+        print("Richtig! Reihenfolge stimmt.")
+        return True
+    print("Leider falsch.")
+    print("Korrekt w\xC3\xA4re:", " ".join(solution))
+    return False
+
+
+if __name__ == "__main__":
+    demo_events = [
+        "Verd\xC3\xA4chtiger verl\xC3\xA4sst das Haus",
+        "Kamera zeichnet ihn auf",
+        "Einbruch passiert",
+        "Polizei trifft ein",
+    ]
+    play_evidence_chain(demo_events)

--- a/minigames/lie_detector.py
+++ b/minigames/lie_detector.py
@@ -1,0 +1,41 @@
+import random
+from typing import List, Dict
+
+
+def evaluate_guess(statement: Dict[str, any], guess_is_lie: bool) -> bool:
+    """Return True if the player's lie guess matches the statement."""
+    return bool(statement.get("is_lie")) == bool(guess_is_lie)
+
+
+def play_lie_detector(statements: List[Dict[str, any]]):
+    """Terminal mini-game to detect lies based on stress indicators."""
+    if not statements:
+        print("Keine Aussagen verf\xc3\xbcgbar.")
+        return 0
+
+    print("[L\xc3\xbcgendetektor] Beurteile die folgenden Aussagen:")
+    correct = 0
+    sample = random.sample(statements, min(len(statements), 5))
+    for st in sample:
+        stress = int(st.get("stress", 0))
+        hearts = "\u2665" * max(1, stress)
+        print(f"{st['suspect']}: {st['statement']}  Stress: {hearts}")
+        ans = input("L\xc3\xbcge? (j/n) ").strip().lower()
+        guess = ans == 'j'
+        if evaluate_guess(st, guess):
+            print("Richtig!")
+            correct += 1
+        else:
+            truth = "L\xc3\xbcge" if st.get('is_lie') else "Wahrheit"
+            print(f"Falsch! Es war eine {truth}.")
+    print(f"Ergebnis: {correct}/{len(sample)} korrekt.")
+    return correct
+
+
+if __name__ == "__main__":
+    demo_statements = [
+        {"suspect": "Alex", "statement": "Ich war zu Hause.", "is_lie": False, "stress": 2},
+        {"suspect": "Sandra", "statement": "Ich kenne das Opfer nicht.", "is_lie": True, "stress": 4},
+        {"suspect": "Kai", "statement": "Ich war im Kino.", "is_lie": False, "stress": 1},
+    ]
+    play_lie_detector(demo_statements)

--- a/minigames/memory_game.py
+++ b/minigames/memory_game.py
@@ -1,0 +1,40 @@
+import random
+from typing import List, Dict
+
+
+def evaluate_answer(statement: Dict[str, str], chosen_statement: str) -> bool:
+    """Return True if the chosen statement matches exactly (case-insensitive)."""
+    return statement["statement"].strip().lower() == chosen_statement.strip().lower()
+
+
+def play_memory_game(statements: List[Dict[str, str]], num_questions: int = 3) -> int:
+    """Terminal memory game. Show statements and later ask the player about them."""
+    if not statements:
+        print("Keine Aussagen vorhanden.")
+        return 0
+
+    print("[Ged\xC3\xA4chtnisspiel] Merke dir die folgenden Aussagen:")
+    for idx, st in enumerate(statements, 1):
+        print(f"{idx}. {st['suspect']}: {st['statement']}")
+    input("Dr\xC3\xBCcke Enter, wenn du bereit bist...")
+
+    correct = 0
+    sample = random.sample(statements, min(num_questions, len(statements)))
+    for st in sample:
+        answer = input(f"Was sagte {st['suspect']}? ").strip()
+        if evaluate_answer(st, answer):
+            print("Richtig!")
+            correct += 1
+        else:
+            print(f"Falsch! Richtige Antwort: {st['statement']}")
+    print(f"Ergebnis: {correct}/{len(sample)} richtig.")
+    return correct
+
+
+if __name__ == "__main__":
+    demo_statements = [
+        {"suspect": "Alex", "statement": "Ich war den ganzen Abend zu Hause."},
+        {"suspect": "Sandra", "statement": "Ich habe mit Freunden gegessen."},
+        {"suspect": "Kai", "statement": "Ich war im Kino."},
+    ]
+    play_memory_game(demo_statements)

--- a/minigames/trace_analysis.py
+++ b/minigames/trace_analysis.py
@@ -1,0 +1,44 @@
+import random
+from typing import List, Dict
+
+
+def evaluate_choice(trace: Dict[str, str], chosen_suspect: str) -> bool:
+    """Return True if the chosen suspect matches the trace's suspect."""
+    return trace["suspect"].strip().lower() == chosen_suspect.strip().lower()
+
+
+def play_trace_analysis(traces: List[Dict[str, str]]):
+    """Simple terminal mini-game for matching traces to suspects."""
+    if not traces:
+        print("Keine Spuren vorhanden.")
+        return 0
+
+    suspects = sorted({t["suspect"] for t in traces})
+    print("[Spurenanalyse] Ordne die Spuren dem richtigen Verd\xC3\xA4chtigen zu.")
+    correct = 0
+    for trace in traces:
+        print(f"\nSpur: {trace['clue']}")
+        for idx, s in enumerate(suspects, 1):
+            print(f" {idx}. {s}")
+        answer = input("Wer war es? ").strip()
+        try:
+            choice_idx = int(answer)
+            chosen = suspects[choice_idx - 1]
+        except (ValueError, IndexError):
+            print("Ung\xC3\xBCltige Eingabe.")
+            continue
+        if evaluate_choice(trace, chosen):
+            print("Richtig!")
+            correct += 1
+        else:
+            print(f"Falsch! Es war {trace['suspect']}.")
+    print(f"Ergebnis: {correct}/{len(traces)} richtig.")
+    return correct
+
+
+if __name__ == "__main__":
+    sample_traces = [
+        {"clue": "Diese Reifenspuren passen zu einem SUV", "suspect": "Alex"},
+        {"clue": "Gefundenes blondes Haar", "suspect": "Sandra"},
+    ]
+    play_trace_analysis(sample_traces)

--- a/scenario_data.py
+++ b/scenario_data.py
@@ -43,14 +43,23 @@ class Suspect:
 
 class Scenario:
     """ Repräsentiert ein Ermittlungs-Szenario (mit mehr Details). """
-    def __init__(self, id, title, description, scene_details, suspects):
-        self.id = id; self.title = title; 
-        self.description = description # Hauptbeschreibung des Falls
+    def __init__(self, id, title, description, scene_details, suspects, bonus_clues=None):
+        self.id = id
+        self.title = title
+        self.description = description  # Hauptbeschreibung des Falls
         # NEU: Details zum Schauplatz
-        self.scene_details = scene_details 
-        self.suspects = {s.id.upper(): s for s in suspects} 
-        self.culprit_id = next((s.id for s in suspects if s.is_culprit), None) 
-        if not self.culprit_id: print(f"WARNUNG: Szenario '{title}' hat keinen Täter!")
+        self.scene_details = scene_details
+        self.suspects = {s.id.upper(): s for s in suspects}
+        self.culprit_id = next((s.id for s in suspects if s.is_culprit), None)
+        if not self.culprit_id:
+            print(f"WARNUNG: Szenario '{title}' hat keinen Täter!")
+        self.bonus_clues = bonus_clues or []
+
+    def get_bonus_hint(self):
+        """Gibt einen zufälligen Bonus-Hinweis zurück, falls verfügbar."""
+        if not self.bonus_clues:
+            return None
+        return random.choice(self.bonus_clues)
              
     def list_suspects_for_display(self):
          """ Gibt eine Liste von Dicts für die Frontend-Anzeige zurück. """
@@ -137,12 +146,18 @@ def load_scenario(scenario_id):
         )
         
         scenario_info = next((s for s in available_scenarios_list if s["id"] == "SPIONAGE01"), None)
+        bonus_clues = [
+            "Auf einem Notizzettel steht der Name 'Apex' geschrieben.",
+            "Jemand hat kurz nach 20 Uhr hektisch das Gebäude verlassen.",
+            "Im Marketingbüro riecht es nach teurem Parfüm.",
+        ]
         return Scenario(
-            id="SPIONAGE01", title=scenario_info['title'], 
-            description=scenario_info['description'], 
-            # NEU: Details zum Schauplatz
+            id="SPIONAGE01",
+            title=scenario_info['title'],
+            description=scenario_info['description'],
             scene_details="Die Büros von TechCorp sind modern, aber gestern Abend wirkten die Flure verlassen. Im Marketingbereich wurde eine offen gelassene Schublade gefunden.",
-            suspects=[suspect1, suspect2, suspect3]
+            suspects=[suspect1, suspect2, suspect3],
+            bonus_clues=bonus_clues,
         )
         
     # === Szenario 2: Mordfall (Müsste ebenso angereichert werden) ===

--- a/tests/test_clue_puzzle.py
+++ b/tests/test_clue_puzzle.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from minigames.clue_puzzle import evaluate_order
+
+
+def test_evaluate_order_correct():
+    solution = ["A", "B", "C"]
+    assert evaluate_order(solution, ["A", "B", "C"])
+
+
+def test_evaluate_order_incorrect():
+    solution = ["A", "B", "C"]
+    assert not evaluate_order(solution, ["B", "A", "C"])

--- a/tests/test_codebreaker.py
+++ b/tests/test_codebreaker.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from minigames.codebreaker import evaluate_guess
+
+
+def test_evaluate_guess_exact_match():
+    assert evaluate_guess('1234', '1234') == (4, 0)
+
+
+def test_evaluate_guess_partial_match():
+    assert evaluate_guess('1234', '1243') == (2, 2)
+
+
+def test_evaluate_guess_no_match():
+    assert evaluate_guess('1234', '5678') == (0, 0)
+
+
+def test_evaluate_guess_length_mismatch():
+    with pytest.raises(ValueError):
+        evaluate_guess('1234', '123')

--- a/tests/test_evidence_chain.py
+++ b/tests/test_evidence_chain.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from minigames.evidence_chain import evaluate_sequence
+
+
+def test_evaluate_sequence_correct():
+    events = ["A", "B", "C"]
+    assert evaluate_sequence(events, ["A", "B", "C"])
+
+
+def test_evaluate_sequence_incorrect():
+    events = ["A", "B", "C"]
+    assert not evaluate_sequence(events, ["B", "A", "C"])

--- a/tests/test_lie_detector.py
+++ b/tests/test_lie_detector.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from minigames.lie_detector import evaluate_guess
+
+
+def test_evaluate_guess_correct_truth():
+    stmt = {"statement": "Ich war zu Hause", "is_lie": False}
+    assert evaluate_guess(stmt, False)
+
+
+def test_evaluate_guess_correct_lie():
+    stmt = {"statement": "Ich kenne das Opfer nicht", "is_lie": True}
+    assert evaluate_guess(stmt, True)
+
+
+def test_evaluate_guess_wrong():
+    stmt = {"statement": "Ich war zu Hause", "is_lie": False}
+    assert not evaluate_guess(stmt, True)

--- a/tests/test_memory_game.py
+++ b/tests/test_memory_game.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from minigames.memory_game import evaluate_answer
+
+
+def test_evaluate_answer_exact_match():
+    st = {"suspect": "Alex", "statement": "Ich war zu Hause."}
+    assert evaluate_answer(st, "Ich war zu Hause.")
+
+
+def test_evaluate_answer_case_insensitive():
+    st = {"suspect": "Alex", "statement": "Ich war im Kino."}
+    assert evaluate_answer(st, "ich war im kino.")
+
+
+def test_evaluate_answer_wrong():
+    st = {"suspect": "Alex", "statement": "Ich war zu Hause."}
+    assert not evaluate_answer(st, "Ich war im Park.")

--- a/tests/test_trace_analysis.py
+++ b/tests/test_trace_analysis.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from minigames.trace_analysis import evaluate_choice
+
+
+def test_evaluate_choice_correct():
+    trace = {"clue": "SUV-Spuren", "suspect": "Alex"}
+    assert evaluate_choice(trace, "Alex")
+
+
+def test_evaluate_choice_wrong():
+    trace = {"clue": "SUV-Spuren", "suspect": "Alex"}
+    assert not evaluate_choice(trace, "Sandra")
+
+
+def test_evaluate_choice_case_insensitive():
+    trace = {"clue": "Blondes Haar", "suspect": "Sandra"}
+    assert evaluate_choice(trace, "sAnDrA")


### PR DESCRIPTION
## Summary
- integrate minigames into gameplay with a new `minigame` command
- provide bonus hints when a minigame is solved
- store bonus clues in the scenario definition
- add helper function to play a random minigame

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846138239a8832182c780e17fa85466