### PR TITLE
Fix openai-whisper installation issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,16 @@ python main.py
 
 ---
 
-## 📦 Anforderungen
+-## 📦 Anforderungen
 
-- Python 3.9 oder neuer
+- Python 3.8 bis 3.11\*
 - Internetverbindung für API-Zugriffe
 - Mikrofon (für Spracheingabe)
 - Lautsprecher (für Sprachausgabe)
+
+\* Das Python-Paket `openai-whisper` unterstützt derzeit keine Python-Versionen
+ab 3.12. Verwende daher eine Umgebung mit Python 3.11 oder älter, damit die
+Installation mit `pip install -r requirements.txt` funktioniert.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify supported Python versions in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684626343cd48321a619c695ff57f3e7