### PR TITLE
Add Docker setup for local and prod environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      ENV_MODE: prod
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: pytest -q
+      - name: Build Docker image
+        run: docker build -t lokaith .

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 aufnahme.wav
 venv/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+ENV PYTHONUNBUFFERED=1
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8004
+
+CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -107,7 +107,38 @@ python -m http.server
 
 ---
 
--## 📦 Anforderungen
+## 🐳 Docker nutzen
+
+Neben der Ausführung auf dem Host kannst du das Projekt auch in Containern
+starten. Es gibt zwei Varianten:
+
+1. **Dev Docker** – bindet deinen Quellcode als Volume ein und eignet sich
+   für schnelle lokale Anpassungen.
+
+```bash
+docker compose -f docker-compose.dev.yml up --build
+```
+
+2. **Prod Docker** – ohne Volume. Diese Variante wird z.B. in GitLab CI/CD
+   verwendet.
+
+```bash
+docker compose -f docker-compose.prod.yml up --build
+```
+
+Beide Konfigurationen lesen deine `.env` Datei und stellen das Backend unter
+<http://localhost:8004> bereit.
+
+---
+
+## 🤖 GitHub Actions
+
+Bei jedem Push laufen die Tests automatisch. Die Konfiguration findest du in
+`.github/workflows/ci.yml`.
+
+---
+
+## 📦 Anforderungen
 
 - Python 3.8 bis 3.11\*
 - Internetverbindung für API-Zugriffe

--- a/app.py
+++ b/app.py
@@ -1,7 +1,8 @@
 # app.py
 from flask import Flask, jsonify, request
-from flask_cors import CORS 
-import random # Für Herzschlag-Zufall
+from flask_cors import CORS
+import random  # Für Herzschlag-Zufall
+import os
 
 # Importiere Logik aus unseren anderen Modulen
 from scenario_data import load_scenario, get_available_scenarios, Suspect
@@ -226,7 +227,8 @@ def accuse_suspect_endpoint():
 
 # --- App starten ---
 if __name__ == '__main__':
-    check_config() 
-    print("Starte Flask Backend Server auf http://localhost:5000 ...")
-    app.run(host='0.0.0.0', port=8004, debug=True) # host='0.0.0.0' kann wichtig sein
+    check_config()
+    debug_mode = os.getenv("ENV_MODE", "dev") != "prod"
+    print("Starte Flask Backend Server auf http://localhost:8004 ...")
+    app.run(host='0.0.0.0', port=8004, debug=debug_mode)  # host='0.0.0.0' kann wichtig sein
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,12 @@
+version: '3.9'
+services:
+  lokaith:
+    build: .
+    env_file: .env
+    environment:
+      - ENV_MODE=dev
+    ports:
+      - "8004:8004"
+    volumes:
+      - .:/app
+    command: python app.py

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,10 @@
+version: '3.9'
+services:
+  lokaith:
+    build: .
+    env_file: .env
+    environment:
+      - ENV_MODE=prod
+    ports:
+      - "8004:8004"
+    command: python app.py


### PR DESCRIPTION
## Summary
- rename `docker-compose.local.yml` to `docker-compose.dev.yml`
- rename `docker-compose.dev.yml` to `docker-compose.prod.yml`
- set `ENV_MODE=dev` for local dev containers and `ENV_MODE=prod` for CI/CD
- update README to document the new dev and prod Docker usage
- adjust debug logic in `app.py`
- add GitHub Actions workflow to run tests and build the Docker image

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68462a9b45ac832193c1c381225063b1